### PR TITLE
Split leave application tests into focused classes

### DIFF
--- a/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceBalanceTest.java
+++ b/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceBalanceTest.java
@@ -1,0 +1,85 @@
+package com.staffs.api.leave.application;
+
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.LeaveRequestRepository;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveApplicationServiceBalanceTest {
+
+    @Mock
+    private LeaveRequestRepository leaveRepo;
+
+    @Mock
+    private StaffRepository staffRepo;
+
+    @InjectMocks
+    private LeaveApplicationService service;
+
+    @Test
+    void remainingDays_updatesStoredBalanceWhenOutOfSync() {
+        var today = LocalDate.of(2024, 6, 15);
+        var staff = StaffJpa.builder()
+                .id("staff-1")
+                .annualLeaveAllocation(20)
+                .leaveRemaining(2)
+                .build();
+        when(staffRepo.findById("staff-1")).thenReturn(Optional.of(staff));
+
+        var approved = List.of(
+                LeaveRequestJpa.builder().startDate(LocalDate.of(2024, 4, 1)).endDate(LocalDate.of(2024, 4, 5)).status(LeaveStatus.APPROVED).build(),
+                LeaveRequestJpa.builder().startDate(LocalDate.of(2024, 5, 1)).endDate(LocalDate.of(2024, 5, 3)).status(LeaveStatus.APPROVED).build()
+        );
+        var yearStart = BusinessYear.start(today);
+        var yearEnd = BusinessYear.end(today);
+        when(leaveRepo.findByStaffIdAndStatusAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                "staff-1", LeaveStatus.APPROVED, yearStart, yearEnd)).thenReturn(approved);
+
+        int remaining = service.remainingDays("staff-1", today);
+
+        assertEquals(12, remaining);
+        verify(staffRepo).save(staff);
+        assertEquals(12, staff.getLeaveRemaining());
+    }
+
+    @Test
+    void remainingDays_doesNotPersistWhenAlreadyCurrent() {
+        var today = LocalDate.of(2024, 6, 15);
+        var staff = StaffJpa.builder()
+                .id("staff-1")
+                .annualLeaveAllocation(15)
+                .leaveRemaining(10)
+                .build();
+        when(staffRepo.findById("staff-1")).thenReturn(Optional.of(staff));
+
+        var approved = List.of(
+                LeaveRequestJpa.builder().startDate(LocalDate.of(2024, 4, 1)).endDate(LocalDate.of(2024, 4, 3)).status(LeaveStatus.APPROVED).build(),
+                LeaveRequestJpa.builder().startDate(LocalDate.of(2024, 4, 10)).endDate(LocalDate.of(2024, 4, 10)).status(LeaveStatus.APPROVED).build()
+        );
+        var yearStart = BusinessYear.start(today);
+        var yearEnd = BusinessYear.end(today);
+        when(leaveRepo.findByStaffIdAndStatusAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                "staff-1", LeaveStatus.APPROVED, yearStart, yearEnd)).thenReturn(approved);
+
+        int remaining = service.remainingDays("staff-1", today);
+
+        assertEquals(10, remaining);
+        verify(staffRepo, never()).save(staff);
+    }
+}

--- a/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceCancellationTest.java
+++ b/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceCancellationTest.java
@@ -1,0 +1,105 @@
+package com.staffs.api.leave.application;
+
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.LeaveRequestRepository;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveApplicationServiceCancellationTest {
+
+    @Mock
+    private LeaveRequestRepository leaveRepo;
+
+    @Mock
+    private StaffRepository staffRepo;
+
+    @InjectMocks
+    private LeaveApplicationService service;
+
+    @Test
+    void cancelApprovedRequest_refreshesRemainingBalanceWithLatestUsage() {
+        var request = LeaveRequestJpa.builder()
+                .id("req-1")
+                .staffId("staff-1")
+                .status(LeaveStatus.APPROVED)
+                .startDate(LocalDate.of(2024, 4, 1))
+                .endDate(LocalDate.of(2024, 4, 5))
+                .build();
+        when(leaveRepo.findById("req-1")).thenReturn(Optional.of(request));
+
+        var staff = StaffJpa.builder()
+                .id("staff-1")
+                .annualLeaveAllocation(25)
+                .leaveRemaining(10)
+                .build();
+        when(staffRepo.findById("staff-1")).thenReturn(Optional.of(staff));
+
+        var otherApproved = List.of(
+                LeaveRequestJpa.builder()
+                        .id("req-2")
+                        .staffId("staff-1")
+                        .status(LeaveStatus.APPROVED)
+                        .startDate(LocalDate.of(2024, 4, 10))
+                        .endDate(LocalDate.of(2024, 4, 12))
+                        .build(),
+                LeaveRequestJpa.builder()
+                        .id("req-3")
+                        .staffId("staff-1")
+                        .status(LeaveStatus.APPROVED)
+                        .startDate(LocalDate.of(2024, 5, 1))
+                        .endDate(LocalDate.of(2024, 5, 3))
+                        .build()
+        );
+        when(leaveRepo.findByStaffIdAndStatusAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                eq("staff-1"), eq(LeaveStatus.APPROVED), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(otherApproved);
+
+        service.cancel("req-1");
+
+        ArgumentCaptor<LeaveRequestJpa> leaveCaptor = ArgumentCaptor.forClass(LeaveRequestJpa.class);
+        verify(leaveRepo).save(leaveCaptor.capture());
+        assertEquals(LeaveStatus.CANCELLED, leaveCaptor.getValue().getStatus());
+
+        ArgumentCaptor<StaffJpa> staffCaptor = ArgumentCaptor.forClass(StaffJpa.class);
+        verify(staffRepo).save(staffCaptor.capture());
+        assertEquals(19, staffCaptor.getValue().getLeaveRemaining());
+    }
+
+    @Test
+    void cancelPendingRequest_doesNotRecalculateRemainingBalance() {
+        var request = LeaveRequestJpa.builder()
+                .id("req-1")
+                .staffId("staff-1")
+                .status(LeaveStatus.PENDING)
+                .startDate(LocalDate.of(2024, 4, 1))
+                .endDate(LocalDate.of(2024, 4, 5))
+                .build();
+        when(leaveRepo.findById("req-1")).thenReturn(Optional.of(request));
+
+        service.cancel("req-1");
+
+        verify(leaveRepo).save(request);
+        verify(staffRepo, never()).save(any());
+        verifyNoMoreInteractions(staffRepo);
+    }
+}

--- a/src/test/java/com/staffs/api/leave/application/LeaveApplicationServicePendingQueryTest.java
+++ b/src/test/java/com/staffs/api/leave/application/LeaveApplicationServicePendingQueryTest.java
@@ -1,0 +1,71 @@
+package com.staffs.api.leave.application;
+
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.LeaveRequestRepository;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveApplicationServicePendingQueryTest {
+
+    @Mock
+    private LeaveRequestRepository leaveRepo;
+
+    @Mock
+    private StaffRepository staffRepo;
+
+    @InjectMocks
+    private LeaveApplicationService service;
+
+    @Test
+    void pendingForTeam_filtersRequestsByDateRange() {
+        var team = List.of(
+                StaffJpa.builder().id("s1").build(),
+                StaffJpa.builder().id("s2").build()
+        );
+        when(staffRepo.findByManagerId("mgr-1")).thenReturn(team);
+
+        var requests = List.of(
+                LeaveRequestJpa.builder().id("r1").staffId("s1").status(LeaveStatus.PENDING)
+                        .startDate(LocalDate.of(2024, 4, 10)).endDate(LocalDate.of(2024, 4, 12)).build(),
+                LeaveRequestJpa.builder().id("r2").staffId("s2").status(LeaveStatus.PENDING)
+                        .startDate(LocalDate.of(2024, 5, 5)).endDate(LocalDate.of(2024, 5, 7)).build(),
+                LeaveRequestJpa.builder().id("r3").staffId("s2").status(LeaveStatus.PENDING)
+                        .startDate(LocalDate.of(2024, 6, 1)).endDate(LocalDate.of(2024, 6, 3)).build()
+        );
+        when(leaveRepo.findByStatusAndStaffIdIn(LeaveStatus.PENDING, List.of("s1", "s2")))
+                .thenReturn(requests);
+
+        var from = LocalDate.of(2024, 5, 1);
+        var to = LocalDate.of(2024, 5, 31);
+        var result = service.pendingForTeam("mgr-1", from, to);
+
+        assertThat(result).extracting(LeaveRequestJpa::getId).containsExactly("r2");
+    }
+
+    @Test
+    void pendingByStaff_returnsOnlyPendingEntries() {
+        var requests = List.of(
+                LeaveRequestJpa.builder().id("r1").status(LeaveStatus.PENDING).build(),
+                LeaveRequestJpa.builder().id("r2").status(LeaveStatus.APPROVED).build(),
+                LeaveRequestJpa.builder().id("r3").status(LeaveStatus.PENDING).build()
+        );
+        when(leaveRepo.findByStaffIdOrderByCreatedAtDesc("staff-1")).thenReturn(requests);
+
+        var result = service.pendingByStaff("staff-1");
+
+        assertThat(result).extracting(LeaveRequestJpa::getId).containsExactly("r1", "r3");
+    }
+}

--- a/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceRequestTest.java
+++ b/src/test/java/com/staffs/api/leave/application/LeaveApplicationServiceRequestTest.java
@@ -1,0 +1,55 @@
+package com.staffs.api.leave.application;
+
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.LeaveRequestRepository;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveApplicationServiceRequestTest {
+
+    @Mock
+    private LeaveRequestRepository leaveRepo;
+
+    @Mock
+    private StaffRepository staffRepo;
+
+    @InjectMocks
+    private LeaveApplicationService service;
+
+    @Test
+    void requestLeave_persistsPendingRequestWhenStaffExists() {
+        var staff = StaffJpa.builder().id("staff-1").build();
+        when(staffRepo.findById("staff-1")).thenReturn(Optional.of(staff));
+        var start = LocalDate.of(2024, 1, 10);
+        var end = start.plusDays(2);
+
+        var result = service.requestLeave("staff-1", start, end);
+
+        ArgumentCaptor<LeaveRequestJpa> captor = ArgumentCaptor.forClass(LeaveRequestJpa.class);
+        verify(leaveRepo).save(captor.capture());
+        LeaveRequestJpa saved = captor.getValue();
+        assertEquals("staff-1", saved.getStaffId());
+        assertEquals(start, saved.getStartDate());
+        assertEquals(end, saved.getEndDate());
+        assertEquals(LeaveStatus.PENDING, saved.getStatus());
+        assertNotNull(saved.getCreatedAt());
+        assertEquals(saved.getId(), result.getId());
+        assertEquals(LeaveStatus.PENDING, result.getStatus());
+    }
+}

--- a/src/test/java/com/staffs/api/leave/application/StaffAdminServiceTest.java
+++ b/src/test/java/com/staffs/api/leave/application/StaffAdminServiceTest.java
@@ -1,0 +1,66 @@
+package com.staffs.api.leave.application;
+
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StaffAdminServiceTest {
+
+    @Mock
+    private StaffRepository staffRepo;
+    @InjectMocks
+    private StaffAdminService service;
+
+    @Test
+    void add_setsRemainingToAllocationWhenMissing() {
+        var staff = StaffJpa.builder()
+                .id("staff-1")
+                .fullName("Test User")
+                .annualLeaveAllocation(22)
+                .leaveRemaining(null)
+                .build();
+
+        when(staffRepo.save(any(StaffJpa.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var saved = service.add(staff);
+
+        ArgumentCaptor<StaffJpa> captor = ArgumentCaptor.forClass(StaffJpa.class);
+        verify(staffRepo).save(captor.capture());
+        assertThat(captor.getValue().getLeaveRemaining()).isEqualTo(22);
+        assertThat(saved.getLeaveRemaining()).isEqualTo(22);
+    }
+
+    @Test
+    void amend_updatesAllocationAndRecomputesRemainingWhenNotProvided() {
+        var existing = StaffJpa.builder()
+                .id("staff-1")
+                .fullName("Test User")
+                .department("Sales")
+                .annualLeaveAllocation(20)
+                .leaveRemaining(5)
+                .build();
+        when(staffRepo.findById("staff-1")).thenReturn(Optional.of(existing));
+        when(staffRepo.save(any(StaffJpa.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var amended = service.amend("staff-1", "Marketing", 25, null);
+
+        ArgumentCaptor<StaffJpa> captor = ArgumentCaptor.forClass(StaffJpa.class);
+        verify(staffRepo).save(captor.capture());
+        StaffJpa saved = captor.getValue();
+        assertThat(saved.getDepartment()).isEqualTo("Marketing");
+        assertThat(saved.getAnnualLeaveAllocation()).isEqualTo(25);
+        assertThat(saved.getLeaveRemaining()).isEqualTo(10);
+        assertThat(amended.getLeaveRemaining()).isEqualTo(10);
+    }
+}


### PR DESCRIPTION
## Summary
- split LeaveApplicationService coverage across dedicated request, cancellation, balance, and pending query test classes
- retain existing scenarios to keep seven smart tests with two heavy lifecycle flows while satisfying multi-file requirement

## Testing
- ./mvnw test *(fails: repository download blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb46519a083219002c011c451aaf9