### PR TITLE
Add unit tests for controllers and API records

### DIFF
--- a/src/test/java/com/staffs/api/identity/api/IdentityControllerTest.java
+++ b/src/test/java/com/staffs/api/identity/api/IdentityControllerTest.java
@@ -1,0 +1,32 @@
+package com.staffs.api.identity.api;
+
+import com.staffs.api.identity.application.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private IdentityController controller;
+
+    @Test
+    void loginDelegatesToServiceAndWrapsToken() {
+        var request = new LoginRequest("user@example.com", "s3cret");
+        when(userService.login("user@example.com", "s3cret")).thenReturn("jwt-token");
+
+        var response = controller.login(request);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getToken()).isEqualTo("jwt-token");
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/AdminControllerTest.java
+++ b/src/test/java/com/staffs/api/leave/api/AdminControllerTest.java
@@ -1,0 +1,86 @@
+package com.staffs.api.leave.api;
+
+import com.staffs.api.leave.application.LeaveApplicationService;
+import com.staffs.api.leave.application.StaffAdminService;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminControllerTest {
+
+    @Mock
+    private StaffAdminService staffAdminService;
+
+    @Mock
+    private LeaveApplicationService leaveApplicationService;
+
+    @InjectMocks
+    private AdminController controller;
+
+    @Test
+    void addDelegatesToStaffAdminService() {
+        var staff = StaffJpa.builder().id("id").fullName("Test Staff").build();
+        when(staffAdminService.add(staff)).thenReturn(staff);
+
+        var result = controller.add(staff);
+
+        assertThat(result).isSameAs(staff);
+        verify(staffAdminService).add(staff);
+    }
+
+    @Test
+    void amendPassesValuesFromRequest() {
+        AmendStaffRequest request = new AmendStaffRequest("IT", 30, 25);
+        var updated = StaffJpa.builder().id("staff").fullName("Name").build();
+        when(staffAdminService.amend("staff", "IT", 30, 25)).thenReturn(updated);
+
+        var response = controller.amend("staff", request);
+
+        assertThat(response).isSameAs(updated);
+        verify(staffAdminService).amend("staff", "IT", 30, 25);
+    }
+
+    @Test
+    void pendingByStaffReturnsPendingRequestsForStaff() {
+        var requests = List.of(LeaveRequestJpa.builder().id("1").build());
+        when(leaveApplicationService.pendingByStaff("staff")).thenReturn(requests);
+
+        assertThat(controller.pendingByStaff("staff")).isSameAs(requests);
+        verify(leaveApplicationService).pendingByStaff("staff");
+    }
+
+    @Test
+    void pendingByTeamReturnsRequests() {
+        var requests = List.of(LeaveRequestJpa.builder().id("2").build());
+        when(leaveApplicationService.pendingByManagerTeam("manager")).thenReturn(requests);
+
+        assertThat(controller.pendingByTeam("manager")).isSameAs(requests);
+        verify(leaveApplicationService).pendingByManagerTeam("manager");
+    }
+
+    @Test
+    void pendingCompanyReturnsCompanyWideRequests() {
+        var requests = List.of(LeaveRequestJpa.builder().id("3").build());
+        when(leaveApplicationService.pendingCompanyWide()).thenReturn(requests);
+
+        assertThat(controller.pendingCompany()).isSameAs(requests);
+        verify(leaveApplicationService).pendingCompanyWide();
+    }
+
+    @Test
+    void approveOnBehalfDelegatesToService() {
+        controller.approveOnBehalf("leaveId");
+
+        verify(leaveApplicationService).adminApproveOnBehalf("leaveId");
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/AdminStaffControllerTest.java
+++ b/src/test/java/com/staffs/api/leave/api/AdminStaffControllerTest.java
@@ -1,0 +1,84 @@
+package com.staffs.api.leave.api;
+
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminStaffControllerTest {
+
+    @Mock
+    private StaffRepository staffRepository;
+
+    @InjectMocks
+    private AdminStaffController controller;
+
+    @Test
+    void addBackfillsLeaveRemainingWhenMissing() {
+        var incoming = StaffJpa.builder()
+                .id("staff")
+                .fullName("Test Staff")
+                .annualLeaveAllocation(25)
+                .build();
+        when(staffRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = controller.add(incoming);
+
+        assertThat(result.getLeaveRemaining()).isEqualTo(25);
+        verify(staffRepository).save(incoming);
+    }
+
+    @Test
+    void updateAmendsDepartmentAndAllocationAndRecalculatesBalance() {
+        var existing = StaffJpa.builder()
+                .id("staff")
+                .fullName("Existing")
+                .department("Ops")
+                .annualLeaveAllocation(20)
+                .leaveRemaining(5)
+                .build();
+        when(staffRepository.findById("staff")).thenReturn(Optional.of(existing));
+        when(staffRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        var incoming = StaffJpa.builder()
+                .department("IT")
+                .annualLeaveAllocation(30)
+                .build();
+
+        var updated = controller.update("staff", incoming);
+
+        assertThat(updated.getDepartment()).isEqualTo("IT");
+        assertThat(updated.getAnnualLeaveAllocation()).isEqualTo(30);
+        assertThat(updated.getLeaveRemaining()).isEqualTo(15);
+        verify(staffRepository).save(existing);
+    }
+
+    @Test
+    void updateClampsExplicitLeaveRemainingToAllocation() {
+        var existing = StaffJpa.builder()
+                .id("staff")
+                .fullName("Existing")
+                .annualLeaveAllocation(20)
+                .leaveRemaining(10)
+                .build();
+        when(staffRepository.findById("staff")).thenReturn(Optional.of(existing));
+        when(staffRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        var incoming = StaffJpa.builder()
+                .leaveRemaining(50)
+                .build();
+
+        var updated = controller.update("staff", incoming);
+
+        assertThat(updated.getLeaveRemaining()).isEqualTo(20);
+        verify(staffRepository).save(existing);
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/AmendStaffRequestTest.java
+++ b/src/test/java/com/staffs/api/leave/api/AmendStaffRequestTest.java
@@ -1,0 +1,17 @@
+package com.staffs.api.leave.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AmendStaffRequestTest {
+
+    @Test
+    void exposesConstructorValues() {
+        AmendStaffRequest request = new AmendStaffRequest("IT", 30, 25);
+
+        assertThat(request.department()).isEqualTo("IT");
+        assertThat(request.annualLeaveAllocation()).isEqualTo(30);
+        assertThat(request.leaveRemaining()).isEqualTo(25);
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/AnalyticsControllerTest.java
+++ b/src/test/java/com/staffs/api/leave/api/AnalyticsControllerTest.java
@@ -1,0 +1,120 @@
+package com.staffs.api.leave.api;
+
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import com.staffs.api.leave.infrastructure.LeaveRequestRepository;
+import com.staffs.api.leave.infrastructure.StaffJpa;
+import com.staffs.api.leave.infrastructure.StaffRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsControllerTest {
+
+    @Mock
+    private LeaveRequestRepository leaveRequestRepository;
+
+    @Mock
+    private StaffRepository staffRepository;
+
+    @InjectMocks
+    private AnalyticsController controller;
+
+    @Test
+    void companyPendingCountsPendingRequests() {
+        when(leaveRequestRepository.findByStatus(LeaveStatus.PENDING))
+                .thenReturn(List.of(LeaveRequestJpa.builder().id("1").build(), LeaveRequestJpa.builder().id("2").build()));
+
+        Map<String, Integer> result = controller.companyPending();
+
+        assertThat(result).containsEntry("pending", 2);
+        verify(leaveRequestRepository).findByStatus(LeaveStatus.PENDING);
+    }
+
+    @Test
+    void usageSummarisesApprovedDaysWithinBusinessYear() {
+        LocalDate today = LocalDate.now();
+        LocalDate yearStart = com.staffs.api.leave.application.BusinessYear.start(today);
+        LocalDate yearEnd = com.staffs.api.leave.application.BusinessYear.end(today);
+        var approved = List.of(
+                LeaveRequestJpa.builder()
+                        .id("1")
+                        .staffId("staff")
+                        .status(LeaveStatus.APPROVED)
+                        .startDate(yearStart)
+                        .endDate(yearStart.plusDays(2))
+                        .build(),
+                LeaveRequestJpa.builder()
+                        .id("2")
+                        .staffId("staff")
+                        .status(LeaveStatus.APPROVED)
+                        .startDate(yearStart.plusDays(10))
+                        .endDate(yearStart.plusDays(10))
+                        .build()
+        );
+        when(leaveRequestRepository.findByStaffIdAndStatusAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                "staff", LeaveStatus.APPROVED, yearStart, yearEnd)).thenReturn(approved);
+
+        Map<String, Object> usage = controller.usage("staff");
+
+        assertThat(usage).containsEntry("staffId", "staff");
+        assertThat(usage).containsEntry("approvedDaysUsed", 4);
+        assertThat(usage).containsEntry("businessYearStart", yearStart);
+        assertThat(usage).containsEntry("businessYearEnd", yearEnd);
+    }
+
+    @Test
+    void teamSnapshotCombinesPendingCountsAndUsageByStaff() {
+        LocalDate today = LocalDate.now();
+        LocalDate yearStart = com.staffs.api.leave.application.BusinessYear.start(today);
+        LocalDate yearEnd = com.staffs.api.leave.application.BusinessYear.end(today);
+        var staffMembers = List.of(
+                StaffJpa.builder().id("s1").fullName("Staff One").annualLeaveAllocation(20).leaveRemaining(10).build(),
+                StaffJpa.builder().id("s2").fullName("Staff Two").annualLeaveAllocation(25).leaveRemaining(12).build()
+        );
+        when(staffRepository.findByManagerId("manager")).thenReturn(staffMembers);
+        when(leaveRequestRepository.findByStatusAndStaffIdIn(eq(LeaveStatus.PENDING), anyList()))
+                .thenReturn(List.of(LeaveRequestJpa.builder().id("p1").build()));
+        when(leaveRequestRepository.findByStaffIdAndStatusAndStartDateGreaterThanEqualAndEndDateLessThanEqual(
+                anyString(), eq(LeaveStatus.APPROVED), any(), any())).thenAnswer(invocation -> {
+            String staffId = invocation.getArgument(0);
+            if ("s1".equals(staffId)) {
+                return List.of(LeaveRequestJpa.builder()
+                        .id("a1")
+                        .staffId("s1")
+                        .status(LeaveStatus.APPROVED)
+                        .startDate(yearStart)
+                        .endDate(yearStart.plusDays(1))
+                        .build());
+            }
+            return List.of(LeaveRequestJpa.builder()
+                    .id("a2")
+                    .staffId("s2")
+                    .status(LeaveStatus.APPROVED)
+                    .startDate(yearStart.plusDays(5))
+                    .endDate(yearStart.plusDays(6))
+                    .build());
+        });
+
+        Map<String, Object> snapshot = controller.teamSnapshot("manager");
+
+        assertThat(snapshot).containsEntry("teamSize", 2);
+        assertThat(snapshot).containsEntry("pendingCount", 1);
+        assertThat(snapshot).containsKey("approvedDaysUsedByStaff");
+        Map<?, ?> usedByStaff = (Map<?, ?>) snapshot.get("approvedDaysUsedByStaff");
+        assertThat(usedByStaff).containsEntry("s1", 2);
+        assertThat(usedByStaff).containsEntry("s2", 2);
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/LeaveControllerTest.java
+++ b/src/test/java/com/staffs/api/leave/api/LeaveControllerTest.java
@@ -1,0 +1,79 @@
+package com.staffs.api.leave.api;
+
+import com.staffs.api.leave.application.LeaveApplicationService;
+import com.staffs.api.leave.domain.model.LeaveRequest;
+import com.staffs.api.leave.domain.model.LeaveStatus;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveControllerTest {
+
+    @Mock
+    private LeaveApplicationService leaveApplicationService;
+
+    @InjectMocks
+    private LeaveController controller;
+
+    @Test
+    void requestConvertsDomainToResponse() {
+        LocalDate start = LocalDate.of(2024, 1, 10);
+        LocalDate end = LocalDate.of(2024, 1, 12);
+        var command = new RequestLeaveCommand(start, end);
+        var leave = LeaveRequest.builder()
+                .id("leave-id")
+                .staffId("user@example.com")
+                .startDate(start)
+                .endDate(end)
+                .status(LeaveStatus.PENDING)
+                .build();
+        when(leaveApplicationService.requestLeave("user@example.com", start, end)).thenReturn(leave);
+
+        LeaveResponse response = controller.request("user@example.com", command);
+
+        assertThat(response.id()).isEqualTo("leave-id");
+        assertThat(response.staffId()).isEqualTo("user@example.com");
+        assertThat(response.startDate()).isEqualTo(start);
+        assertThat(response.endDate()).isEqualTo(end);
+        assertThat(response.status()).isEqualTo("PENDING");
+        verify(leaveApplicationService).requestLeave("user@example.com", start, end);
+    }
+
+    @Test
+    void cancelDelegatesToService() {
+        controller.cancel("leave-123");
+
+        verify(leaveApplicationService).cancel("leave-123");
+    }
+
+    @Test
+    void myReturnsRequestsFromService() {
+        var requests = List.of(LeaveRequestJpa.builder().id("1").build());
+        when(leaveApplicationService.myRequests("user@example.com")).thenReturn(requests);
+
+        assertThat(controller.my("user@example.com")).isSameAs(requests);
+        verify(leaveApplicationService).myRequests("user@example.com");
+    }
+
+    @Test
+    void myBalanceReturnsRemainingDays() {
+        when(leaveApplicationService.remainingDays(eq("user@example.com"), any(LocalDate.class))).thenReturn(7);
+
+        int result = controller.myBalance("user@example.com");
+
+        assertThat(result).isEqualTo(7);
+        verify(leaveApplicationService).remainingDays(eq("user@example.com"), any(LocalDate.class));
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/LeaveResponseTest.java
+++ b/src/test/java/com/staffs/api/leave/api/LeaveResponseTest.java
@@ -1,0 +1,24 @@
+package com.staffs.api.leave.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LeaveResponseTest {
+
+    @Test
+    void storesProvidedValues() {
+        LocalDate start = LocalDate.of(2024, 2, 1);
+        LocalDate end = LocalDate.of(2024, 2, 5);
+
+        LeaveResponse response = new LeaveResponse("id", "staff", start, end, "PENDING");
+
+        assertThat(response.id()).isEqualTo("id");
+        assertThat(response.staffId()).isEqualTo("staff");
+        assertThat(response.startDate()).isEqualTo(start);
+        assertThat(response.endDate()).isEqualTo(end);
+        assertThat(response.status()).isEqualTo("PENDING");
+    }
+}

--- a/src/test/java/com/staffs/api/leave/api/ManagerControllerTest.java
+++ b/src/test/java/com/staffs/api/leave/api/ManagerControllerTest.java
@@ -1,0 +1,67 @@
+package com.staffs.api.leave.api;
+
+import com.staffs.api.leave.application.LeaveApplicationService;
+import com.staffs.api.leave.infrastructure.LeaveRequestJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ManagerControllerTest {
+
+    @Mock
+    private LeaveApplicationService leaveApplicationService;
+
+    @InjectMocks
+    private ManagerController controller;
+
+    @Test
+    void pendingReturnsTeamRequestsWithinDates() {
+        LocalDate from = LocalDate.of(2024, 5, 1);
+        LocalDate to = LocalDate.of(2024, 5, 31);
+        var expected = List.of(LeaveRequestJpa.builder().id("1").build());
+        when(leaveApplicationService.pendingForTeam("manager@example.com", from, to)).thenReturn(expected);
+
+        var result = controller.pending("manager@example.com", from, to);
+
+        assertThat(result).isSameAs(expected);
+        verify(leaveApplicationService).pendingForTeam("manager@example.com", from, to);
+    }
+
+    @Test
+    void approveDelegatesToService() {
+        controller.approve("leave-1");
+
+        verify(leaveApplicationService).approve("leave-1");
+    }
+
+    @Test
+    void rejectDelegatesToService() {
+        controller.reject("leave-2");
+
+        verify(leaveApplicationService).reject("leave-2");
+    }
+
+    @Test
+    void staffBalanceReturnsRemainingDaysForStaff() {
+        when(leaveApplicationService.remainingForStaff(eq("staff-1"), any(LocalDate.class))).thenReturn(9);
+
+        int balance = controller.staffBalance("staff-1");
+
+        assertThat(balance).isEqualTo(9);
+        ArgumentCaptor<LocalDate> captor = ArgumentCaptor.forClass(LocalDate.class);
+        verify(leaveApplicationService).remainingForStaff(eq("staff-1"), captor.capture());
+        assertThat(captor.getValue()).isEqualTo(LocalDate.now());
+    }
+}


### PR DESCRIPTION
## Summary
- add isolated unit tests for the identity and leave management controllers
- cover basic data behaviour of the LeaveResponse and AmendStaffRequest records

## Testing
- mvn test *(fails: unable to download dependencies because the Maven Central repository was unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec45f55b883219958c6035f03e2cc